### PR TITLE
feat: Overhaul the addon with new options

### DIFF
--- a/ollama/README.md
+++ b/ollama/README.md
@@ -1,17 +1,23 @@
 # Ollama Addon for Home Assistant
 
+Please note that this addon runs with CPU acceleration or experimental Nvidia GPU Support (please report if it works for you!). For ROCm the support is still pending.
+
 ## Model Directory
 
-All downloaded models are stored `/config/ollama`. Please make sure that you have sufficient space available.
+All downloaded models are stored `/share/ollama` by default. For historic reasons you can also configure it for `/config/ollama`. Please make sure that you have sufficient space available.
 
 ## Ollama Integration
 
+To download any models either use the API of Ollama or integrate with the Home Assistant Integration [Ollama](https://www.home-assistant.io/integrations/ollama/):
+
 [![Add Ollama Integration](https://my.home-assistant.io/badges/brand.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=ollama)
 
-To integrate with the default [Ollama](https://www.home-assistant.io/integrations/ollama/) integration use the following data:
+Use the following data:
 
 - URL: `http://76e18fb5-ollama:11434`
 
-## Note
+If you want to change the model, delete the integration (not the addon!) and restart the process for the configuration of the integration.
 
-By default the container runs with CPU acceleration only. If you are interesting in getting GPU support, please check the [Website of the Ollama Container Image](https://hub.docker.com/r/ollama/ollama).
+## Note on the UI Link
+
+The UI Link is only there to check if the API of ollama is available. There is no chat functionality included in the official image of ollama.

--- a/ollama/config.yaml
+++ b/ollama/config.yaml
@@ -1,5 +1,5 @@
 name: "Ollama"
-description: "Get up and running with large language models"
+description: "Get up and running with large language models."
 # renovate: datasource=github-tags depName=ollama/ollama
 version: "0.5.12"
 slug: "ollama"
@@ -7,20 +7,47 @@ arch:
   - aarch64
   - amd64
 url: https://ollama.com
-environment:
-  OLLAMA_MODELS: "/config/ollama"
-  # Keep model loaded in memory
-  OLLAMA_KEEP_ALIVE: "-1"
 map:
   - config:rw
+  - share:rw
 image: docker.io/ollama/ollama
 init: false
 ingress: true
+legacy: true
+video: true
 ingress_port: 11434
 ingress_stream: true
 ports:
   11434/tcp: 11434
 ports_description:
-  11434/tcp: "Ollama API"
+  11434/tcp: "The Ollama API Port, not used for End-User Access"
+options:
+  OLLAMA_MODELS: /share/ollama
+  OLLAMA_KEEP_ALIVE: -1
+  OLLAMA_KV_CACHE_TYPE: q8_0
+  OLLAMA_FLASH_ATTENTION: 0
+  OLLAMA_MAX_LOADED_MODELS: 1
+  OLLAMA_NUM_PARALLEL: 1
+  OLLAMA_ORIGINS: ""
+  gpus: all
+schema:
+  OLLAMA_FLASH_ATTENTION: int
+  OLLAMA_MODELS: list(/config/ollama|/share/ollama)
+  OLLAMA_KEEP_ALIVE: int
+  OLLAMA_KV_CACHE_TYPE: list(f16|q8_0|q4_0)
+  OLLAMA_MAX_LOADED_MODELS: int
+  OLLAMA_NUM_PARALLEL: int
+  OLLAMA_ORIGINS: str
+  gpus: str
+devices:
+  - /dev/dri/renderD128
+  - /dev/apex_0
+  - /dev/apex_1
+  - /dev/apex_2
+  - /dev/apex_3
+  - /dev/dri/card0
+  - /dev/vchiq
+  - /dev/video10
+  - /dev/video0
 startup: application
 watchdog: tcp://[HOST]:[PORT:11434]

--- a/ollama/translations/en.yaml
+++ b/ollama/translations/en.yaml
@@ -1,0 +1,22 @@
+configuration:
+  OLLAMA_MODELS:
+    name: OLLAMA_MODELS
+    description: Directory where the downloaded models are stored, ensure sufficient space
+  OLLAMA_KEEP_ALIVE:
+    name: OLLAMA_KEEP_ALIVE
+    description: Keep the model loaded in memory, set to -1 to keep it loaded
+  OLLAMA_KV_CACHE_TYPE:
+    name: OLLAMA_KV_CACHE_TYPE
+    description: The type of cache to use, q8_0 is recommended for most users. Only when FLASH_ATTENTION is enabled
+  OLLAMA_FLASH_ATTENTION:
+    name: OLLAMA_FLASH_ATTENTION
+    description: Enable flash attention for faster inference (only on GPU)
+  OLLAMA_MAX_LOADED_MODELS:
+    name: OLLAMA_MAX_LOADED_MODELS
+    description: The maximum number of models to keep loaded in memory
+  OLLAMA_NUM_PARALLEL:
+    name: OLLAMA_NUM_PARALLEL
+    description: The number of parallel requests to handle
+  OLLAMA_ORIGINS:
+    name: OLLAMA_ORIGINS
+    description: The allowed origins for the API, set to "*" to allow all. Clear to set to the default locations

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,10 +22,10 @@
     {
       "matchManagers": ["pre-commit"],
       "automerge": true,
-      "automergeType": "branch",
+      "automergeType": "pr",
       "semanticCommitType": "chore"
 
     }
   ],
-  minimumReleaseAge: "24 hours",
+  minimumReleaseAge: "12 hours",
 }


### PR DESCRIPTION
BREAKING CHANGE:
- The ollama directory was moved to /share to allow for exclusion from backups. The previous directory under /config can still be configured. If you want to continue using it, please make sure to configure the settings of the addon accordingly.