### PR TITLE
feat: persist Ollama Cloud credentials across addon restarts

### DIFF
--- a/ollama/README.md
+++ b/ollama/README.md
@@ -18,6 +18,18 @@ Use the following data:
 
 If you want to change the model, delete the integration (not the addon!) and restart the process for the configuration of the integration.
 
+## Ollama Cloud Models
+
+Ollama supports cloud-hosted models that run on Ollama's infrastructure, useful for large models that don't fit on a local GPU. To use cloud models, run the following inside the addon container and follow the sign-in URL:
+
+```bash
+ollama run gpt-oss:120b-cloud
+```
+
+Cloud credentials are stored in `~/.ollama/` and persisted to `/share/.ollama/` across addon restarts (via the `HOME` option).
+
+Read more at the [Ollama Cloud documentation](https://docs.ollama.com/cloud).
+
 ## Note on the UI Link
 
 The UI Link is only there to check if the API of ollama is available. There is no chat functionality included in the official image of ollama.

--- a/ollama/config.yaml
+++ b/ollama/config.yaml
@@ -29,6 +29,7 @@ options:
   OLLAMA_MAX_LOADED_MODELS: 1
   OLLAMA_NUM_PARALLEL: 1
   OLLAMA_ORIGINS: ""
+  HOME: /share
   gpus: all
 schema:
   OLLAMA_CONTEXT_LENGTH: int?
@@ -51,6 +52,7 @@ schema:
   OLLAMA_CONTEXT_LENGTH: int?
   OLLAMA_ORIGINS: str
   HTTPS_PROXY: str?
+  HOME: str
   gpus: str
 backup_exclude:
   - "ollama/**"

--- a/ollama/translations/en.yaml
+++ b/ollama/translations/en.yaml
@@ -23,3 +23,6 @@ configuration:
   OLLAMA_VULKAN:
     name: OLLAMA_VULKAN
     description: Additional GPU Support. Read [the docs](https://docs.ollama.com/gpu#vulkan-gpu-support) for more information.
+  HOME:
+    name: HOME
+    description: Home directory for the Ollama process. Set to /share (default) so that Ollama Cloud credentials (stored in ~/.ollama) persist across addon restarts.


### PR DESCRIPTION
## Problem

On every addon restart, `/root/.ollama/` is wiped (ephemeral container storage), causing Ollama to regenerate a new ed25519 keypair. This breaks Ollama Cloud authentication since the device identity changes on every restart.

Fixes #197
Closes #219

## Solution

Set `HOME=/share` so that `~/.ollama/` (containing the ed25519 keypair and cloud auth tokens) is stored in `/share/.ollama/`, which is already a persistent mapped volume.

**Changes:**
- `config.yaml`: add `HOME: /share` to `options` and `schema`
- `README.md`: document the Ollama Cloud sign-in flow
- `translations/en.yaml`: add description for `HOME` option

## How to test

1. Install/update the addon
2. Run `ollama run gpt-oss:120b-cloud` inside the container and visit the sign-in URL once
3. Restart the addon — credentials persist, no new keypair is generated