### PR TITLE
fix: Add /dev/kfd to list of devices for rocm

### DIFF
--- a/ollama/config.yaml
+++ b/ollama/config.yaml
@@ -61,6 +61,7 @@ devices:
   - /dev/apex_2
   - /dev/apex_3
   - /dev/dri/card0
+  - /dev/kfd
   - /dev/vchiq
   - /dev/video10
   - /dev/video0


### PR DESCRIPTION
Fixes #309