### PR TITLE
feat: Authentication via API Keys and move home

### DIFF
--- a/ollama/README.md
+++ b/ollama/README.md
@@ -20,13 +20,16 @@ If you want to change the model, delete the integration (not the addon!) and res
 
 ## Ollama Cloud Models
 
-Ollama supports cloud-hosted models that run on Ollama's infrastructure, useful for large models that don't fit on a local GPU. To use cloud models, run the following inside the addon container and follow the sign-in URL:
+Ollama supports cloud-hosted models that run on Ollama's infrastructure, useful for large models that don't fit on a local GPU.
 
-```bash
-ollama run gpt-oss:120b-cloud
-```
+You have two possibilities for authentication:
 
-Cloud credentials are stored in `~/.ollama/` and persisted to `/share/.ollama/` across addon restarts (via the `HOME` option).
+- Public-Private-Key Authentication:
+  - Look at the logs of this addon where the key is displayed and add this key to your [ollama account as a device key](https://ollama.com/settings/keys).
+  - Locally, the cloud credentials are stored in `~/.ollama/` and persisted to `/data/.ollama/` across addon restarts (via the `HOME` option).
+- API Key:
+  - Create an API key at [ollama.com/settings/keys](https://ollama.com/settings/keys)
+  - Set the `OLLAMA_API_KEY` option in the addon configuration
 
 Read more at the [Ollama Cloud documentation](https://docs.ollama.com/cloud).
 

--- a/ollama/config.yaml
+++ b/ollama/config.yaml
@@ -29,9 +29,10 @@ options:
   OLLAMA_MAX_LOADED_MODELS: 1
   OLLAMA_NUM_PARALLEL: 1
   OLLAMA_ORIGINS: ""
-  HOME: /share
+  HOME: /data
   gpus: all
 schema:
+  OLLAMA_API_KEY: str?
   OLLAMA_CONTEXT_LENGTH: int?
   OLLAMA_FLASH_ATTENTION: int
   OLLAMA_MODELS: list(/config/ollama|/share/ollama|/data/ollama)

--- a/ollama/translations/en.yaml
+++ b/ollama/translations/en.yaml
@@ -1,4 +1,7 @@
 configuration:
+  OLLAMA_API_KEY:
+    name: OLLAMA_API_KEY
+    description: API key for authenticating with Ollama Cloud (ollama.com) to use cloud-hosted models. Create a key at https://ollama.com/settings/keys.
   OLLAMA_MODELS:
     name: OLLAMA_MODELS
     description: Directory where the downloaded models are stored, ensure sufficient space


### PR DESCRIPTION
Add also the option of API Keys.

Additionally the default of /data is more secure compared to the /share directory as it is addon-specific and only visible from the container host.