### PR TITLE
Add OLLAMA_IGPU_ENABLE option for Intel integrated GPUs

### DIFF
--- a/ollama/config.yaml
+++ b/ollama/config.yaml
@@ -42,6 +42,7 @@ schema:
   OLLAMA_NUM_PARALLEL: int
   OLLAMA_NUM_THREAD: int?
   OLLAMA_VULKAN: bool?
+  OLLAMA_IGPU_ENABLE: bool?
   # https://github.com/ollama/ollama/issues/13108
   GGML_VK_DISABLE_INTEGER_DOT_PRODUCT: bool?
   OLLAMA_NOPRUNE: bool?

--- a/ollama/translations/en.yaml
+++ b/ollama/translations/en.yaml
@@ -26,6 +26,9 @@ configuration:
   OLLAMA_VULKAN:
     name: OLLAMA_VULKAN
     description: Additional GPU Support. Read [the docs](https://docs.ollama.com/gpu#vulkan-gpu-support) for more information.
+  OLLAMA_IGPU_ENABLE:
+    name: OLLAMA_IGPU_ENABLE
+    description: Enable use of integrated GPUs (e.g. Intel Iris Xe). Requires OLLAMA_VULKAN to be enabled. Disabled by default to preserve current behaviour.
   HOME:
     name: HOME
     description: Home directory for the Ollama process. Set to /share (default) so that Ollama Cloud credentials (stored in ~/.ollama) persist across addon restarts.


### PR DESCRIPTION
Expose the OLLAMA_IGPU_ENABLE environment variable as an optional add-on setting so users with supported Intel iGPUs (e.g. Iris Xe, UHD Graphics) can keep the integrated GPU enabled instead of being dropped by Ollama at startup.

Defaults to unset, preserving the current behaviour (iGPU disabled) for existing installations. Requires OLLAMA_VULKAN to be enabled.

Closes #319